### PR TITLE
First Open Access date retraction period

### DIFF
--- a/cfg/cfg.d/zz_hefce_oa.pl
+++ b/cfg/cfg.d/zz_hefce_oa.pl
@@ -26,6 +26,39 @@ push @{ $c->{user_roles}->{admin} }, qw{ +report/hefce_oa };
 #set if embargoed records should appear in report as compliant
 $c->{hefce_oa}->{embargo_as_compliant} = 0;
 
+# First Open Access (FOA) retraction period.
+# If this configuration value is set, and an item is updated within the number of day specified,
+# the FOA date can be removed, if the items no loinger has an appropriate Open Access document attached.
+# If the value below is commented-out, or undef, no FOA retractions will happen.
+# If the value below is 0, then only updates on the same day can alter the FOA date.
+# If the value below is 1, then updates on the same day, or the day after the FOA date may change the value.
+# A value of 2 means up to 2 days after the FOA date... etc.
+# The value below
+$c->{hefce_oa}->{foa_retraction_period} = undef; #number of days
+
+# The value above is referenced in the following method, called by a commit trigger
+$c->{hefce_oa}->{commit_in_foa_retraction_period} = sub
+{
+	my( $repo, $date_foa ) = @_;
+
+	use Time::Piece;
+	use Time::Seconds;
+
+	return unless defined $date_foa;
+	my $period = $repo->config( "hefce_oa", "foa_retraction_period" );
+	return unless defined $period;
+
+
+	my $retraction_end = Time::Piece->strptime( $date_foa, "%Y-%m-%d"); #defaults to 00:00:00
+	$retraction_end += ONE_DAY * $period;
+
+	# older versions of Time::Piece don't have the 'truncate' method. The below should return
+	# a consistent date for comparisons
+	my $today = Time::Piece->strptime( EPrints::Time::get_iso_date(), "%Y-%m-%d" );
+
+	return 1 if $today <= $retraction_end;  
+};
+
 $c->{hefce_report}->{exportfields} = {
 	ref_core => [ qw(
         	eprintid


### PR DESCRIPTION
This adds a call to `$c->{hefce_oa}->{commit_in_foa_retraction_period}` from a document update trigger.

The behaviour is controlled with the following setting: 
`$c->{hefce_oa}->{foa_retraction_period} = undef;`

If this is commented-out, or set to undef, nothing different to previous releases will happen.
If the above value is set, and a document changes from open-to-closed, the parent EPrint will re-calculate the FOA status - if the EPrint still has an OA document, the previous value is retained.

NB There may also be a requirement to run a similar calculation at the EPrint level - if an EPrint is moved to 'archive' and then back to review within a short amount of time, then the discovery date, or FOA may be incorrect.
With the code in this PR, only updates to the document will cause the FOA date to be changed.
An EPrint could be moved to live, and then back to review (and left there for a while).