### PR TITLE
Deduce panel

### DIFF
--- a/cfg/cfg.d/zz_hefce_oa_deduce_panels.pl
+++ b/cfg/cfg.d/zz_hefce_oa_deduce_panels.pl
@@ -1,0 +1,66 @@
+# To automatically use panels based on divisions, set the following hash to
+# your academic structure. You only need to define the nodes that are different
+# to their parents. If everything in Faculty X is an 'AB', you can just set the
+# faculty to 'AB'. If e.g. one department within an 'AB' faculty is 'CD', define
+# that.
+#
+# The panel test defaults to a 'CD' panel. If you set the top-level divisions to
+# 'AB', this will be the default where other divisions are not defined.
+
+my %divisions_panels = (
+	#'divisions' => 'AB', # by default anything under 'divisions'
+	'fac_eng' => 'AB',
+	'sch_geo' => 'CD', # an outlier
+	'fac_law' => 'CD',
+	'fac_med' => 'AB',
+	'sch_psy' => 'CD',
+);
+
+$c->{hefce_oa}->{divisions_panels} = \%divisions_panels;
+
+$c->{hefce_oa}->{deduce_panel} = sub {
+	my( $eprint ) = @_;
+
+	my $debug = 0;
+
+	print STDERR "Deducing panels\n" if $debug;
+
+	my $repo = $eprint->repository;
+	my $div_panels = $repo->get_conf( 'hefce_oa', 'divisions_panels' );
+
+	my %panels;
+
+	foreach my $subj ( @{$eprint->get_value( 'divisions' )} )
+	{
+# check if we are defined in the panels hash
+		if( defined $iau_panels->{$subj} ){
+			$panels{$subj} = $div_panels->{$subj};
+			next;
+		}
+
+		my $subject = EPrints::DataObj::Subject->new( $repo, $subj );
+
+		if( defined $subject ){
+# step through ancestors to see if any are defined
+			foreach ( $subject->_get_ancestors ){
+# stop once we find something
+				if( defined $div_panels->{$_} ){
+					$panels{$_} = $div_panels->{$_};
+					last;
+				}
+			}
+		}
+
+	}
+	use Data::Dumper;
+	print STDERR "Panels: ", Dumper( %panels ) if $debug;
+
+# return shortest panel if it exsits
+	return "AB" if ( grep{ $panels{$_} eq "AB" } keys %panels );
+	return "CD" if ( grep{ $panels{$_} eq "CD" } keys %panels );
+
+#definite return otherwise we return the value of the last grep (which would be 0).
+# an 'undef' value returned here indicates no deduction has taken place.
+	return;
+}
+

--- a/cfg/cfg.d/zz_hefce_oa_deduce_panels.pl
+++ b/cfg/cfg.d/zz_hefce_oa_deduce_panels.pl
@@ -6,46 +6,52 @@
 #
 # The panel test defaults to a 'CD' panel. If you set the top-level divisions to
 # 'AB', this will be the default where other divisions are not defined.
-
-my %divisions_panels = (
-	#'divisions' => 'AB', # by default anything under 'divisions'
+#
+# EPrint fieldname to deduce the panels from
+$c->{hefce_oa}->{panel_deduction_field} = 'divisions';
+#
+# mapping from the above fieldname to panels
+$c->{hefce_oa}->{panel_deduction_map} = {
+	#'divisions' => 'AB', # e.g. anything under 'divisions' should be 'AB'
 	'fac_eng' => 'AB',
-	'sch_geo' => 'CD', # an outlier
+	'sch_geo' => 'CD', # e.g. an outlier in the above faculty
 	'fac_law' => 'CD',
 	'fac_med' => 'AB',
 	'sch_psy' => 'CD',
-);
+};
 
-$c->{hefce_oa}->{divisions_panels} = \%divisions_panels;
 
 $c->{hefce_oa}->{deduce_panel} = sub {
 	my( $eprint ) = @_;
 
 	my $debug = 0;
-
 	print STDERR "Deducing panels\n" if $debug;
 
 	my $repo = $eprint->repository;
-	my $div_panels = $repo->get_conf( 'hefce_oa', 'divisions_panels' );
+	my $field = $repo->get_conf( 'hefce_oa', 'panel_deduction_field' );
+	return unless defined $field && $eprint->exists_and_set( $field );
+
+	my $panel_map = $repo->get_conf( 'hefce_oa', 'panel_deduction_map' );
+	return unless defined $panel_map;
 
 	my %panels;
 
-	foreach my $subj ( @{$eprint->get_value( 'divisions' )} )
+	foreach my $subj ( @{$eprint->get_value( $field )} )
 	{
-# check if we are defined in the panels hash
-		if( defined $div_panels->{$subj} ){
-			$panels{$subj} = $div_panels->{$subj};
+		# check if we are defined in the panels map
+		if( defined $panel_map->{$subj} ){
+			$panels{$subj} = $panel_map->{$subj};
 			next;
 		}
 
 		my $subject = EPrints::DataObj::Subject->new( $repo, $subj );
 
 		if( defined $subject ){
-# step through ancestors to see if any are defined
+			# step through ancestors to see if any are defined
 			foreach ( $subject->_get_ancestors ){
-# stop once we find something
-				if( defined $div_panels->{$_} ){
-					$panels{$_} = $div_panels->{$_};
+				# stop once we find something
+				if( defined $panel_map->{$_} ){
+					$panels{$_} = $panel_map->{$_};
 					last;
 				}
 			}
@@ -55,12 +61,12 @@ $c->{hefce_oa}->{deduce_panel} = sub {
 	use Data::Dumper;
 	print STDERR "Panels: ", Dumper( %panels ) if $debug;
 
-# return shortest panel if it exsits
+	# return shortest panel if it exsits
 	return "AB" if ( grep{ $panels{$_} eq "AB" } keys %panels );
 	return "CD" if ( grep{ $panels{$_} eq "CD" } keys %panels );
 
-#definite return otherwise we return the value of the last grep (which would be 0).
-# an 'undef' value returned here indicates no deduction has taken place.
+	#definite return otherwise we return the value of the last grep (which would be 0).
+	# an 'undef' value returned here indicates no deduction has taken place.
 	return;
 }
 

--- a/cfg/cfg.d/zz_hefce_oa_deduce_panels.pl
+++ b/cfg/cfg.d/zz_hefce_oa_deduce_panels.pl
@@ -33,7 +33,7 @@ $c->{hefce_oa}->{deduce_panel} = sub {
 	foreach my $subj ( @{$eprint->get_value( 'divisions' )} )
 	{
 # check if we are defined in the panels hash
-		if( defined $iau_panels->{$subj} ){
+		if( defined $div_panels->{$subj} ){
 			$panels{$subj} = $div_panels->{$subj};
 			next;
 		}

--- a/lib/cfg.d/hefce_oa_tests.pl
+++ b/lib/cfg.d/hefce_oa_tests.pl
@@ -229,7 +229,14 @@ $c->{hefce_oa}->{run_test_ACC_EMBARGO} = sub {
 	my( $repo, $eprint, $flag ) = @_;
 
 	my $len = $eprint->value( "hoa_emb_len" ) || 0;
-	my $max = ( $eprint->value( "hoa_ref_pan" ) || "CD" ) eq "AB" ? 12 : 24;
+
+	my $pan = $eprint->value( "hoa_ref_pan" );
+    if( !defined $pan && $repo->can_call( 'hefce_oa', 'deduce_panel' ) )
+    {
+        $pan = $repo->call( [ 'hefce_oa', 'deduce_panel' ], $eprint );
+    }
+
+	my $max = ( defined $pan && $pan eq "AB" ) ? 12 : 24;
 
 	return 1 unless $len > $max;
 

--- a/lib/lang/en/phrases/hefce_oa.xml
+++ b/lib/lang/en/phrases/hefce_oa.xml
@@ -170,6 +170,7 @@ as part of our more detailed work to develop the post-2014 REF.
 
 <epp:phrase id="Plugin/Screen/EPrint/HefceOA:data:title">Data used to check compliance</epp:phrase>
 <epp:phrase id="Plugin/Screen/EPrint/HefceOA:data:unknown">?</epp:phrase>
+<epp:phrase id="Plugin/Screen/EPrint/HefceOA:data:deduced_panel"> (deduced panel: <epc:pin name="panel"/>)</epp:phrase>
 
 <!-- Incomplete dates -->
 <epp:phrase id="Plugin/Screen/EPrint/HefceOA:render_incomplete_dates">The following fields have incomplete dates. Incomplete dates may lead to inaccurate reporting of compliance.<ul><epc:pin name="dates"/></ul></epp:phrase>

--- a/lib/plugins/EPrints/Plugin/Screen/EPrint/HefceOA.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/EPrint/HefceOA.pm
@@ -214,6 +214,15 @@ sub render_data
 
 		my $td = $repo->xml->create_element( "td", class => "ep_row" );
 		$td->appendChild( $eprint->is_set( $field ) ? $eprint->render_value( $field ) : $self->html_phrase( "data:unknown" ) );
+
+		if( $field eq "hoa_ref_pan" && !$eprint->is_set( $field ) && $repo->can_call( 'hefce_oa', 'deduce_panel' ) )
+		{
+			my $deduced_panel = $repo->call( [ 'hefce_oa', 'deduce_panel' ], $eprint );
+			if( defined $deduced_panel )
+			{
+				$td->appendChild( $self->html_phrase( "data:deduced_panel", panel => $repo->make_text( $deduced_panel ) ) );
+			}
+		}
 		$tr->appendChild( $td );
 	}
 


### PR DESCRIPTION
By default calculate which panel an EPrint may be submitted to by looking at the 'divisions' field.

In the REF_CC 'Data used to check compliance', the a panel will be shown as deduced when this is the case.
If a panel is explicitly set for an EPrint, the deduction does not take place.
